### PR TITLE
Missing dependency on packaging.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         'six',
         'openpyxl>=2.4.8',
         'babel>=2.3.4',
+        'packaging>=20.4',
     ],
     zip_safe=False,
     include_package_data=True,


### PR DESCRIPTION
 - Not sure what the minimum version needed actually is. Just picked stable:

- reproduce: create a new venv. Install 'xlsx2html'. Then:

```
>>> import xlsx2html
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../venv/lib/python2.7/site-packages/xlsx2html/__init__.py", line 3, in <module>
    from .core import xlsx2html
  File "...tmp/xlsx2html/venv/lib/python2.7/site-packages/xlsx2html/core.py", line 11, in <module>
    from xlsx2html.compat import OPENPYXL_24
  File ".../tmp/xlsx2html/venv/lib/python2.7/site-packages/xlsx2html/compat.py", line 2, in <module>
    from packaging import version
ImportError: No module named packaging
```