### PR TITLE
Fix indexed colors

### DIFF
--- a/xlsx2html/core.py
+++ b/xlsx2html/core.py
@@ -76,8 +76,12 @@ def normalize_color(color):
     if color.type == 'rgb':
         rgb = color.rgb
     if color.type == 'indexed':
-        rgb = COLOR_INDEX[color.indexed]
-        if not aRGB_REGEX.match(rgb):
+        try:
+            rgb = COLOR_INDEX[color.indexed]
+        except IndexError:
+            # The indices 64 and 65 are reserved for the system foreground and background colours respectively
+            pass
+        if not rgb or not aRGB_REGEX.match(rgb):
             # TODO system fg or bg
             rgb = '00000000'
     if rgb:


### PR DESCRIPTION
There was a situation when an indexed color with an index of 64 came in. The openpyxl documentation says that "indices 64 and 65 are reserved for the system foreground and background colors respectively". Fixed by catching IndexError.