### PR TITLE
Excel-similar datetime format parsing

### DIFF
--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -5,7 +5,8 @@ import datetime
 
 import pytest
 
-from xlsx2html.format import format_decimal, format_date, format_datetime, format_time
+from xlsx2html.format import format_decimal
+from xlsx2html.format import format_date, format_datetime, format_time, format_timedelta
 from xlsx2html.format.dt import normalize_datetime_format
 
 decimal_formats = [
@@ -57,9 +58,6 @@ def test_currency_format(fmt_kw, expected):
     assert format_decimal(*fmt_kw) == expected
 
 
-dt = datetime.datetime(2019, 12, 25, 6, 9, 5)
-
-
 test_datetime_formats = {
     'mm-dd-yy': 'MM-dd-yy',
     'd-mmm-yy': 'd-MMM-yy',
@@ -99,6 +97,9 @@ def test_normalize_format(xlfmt, bfmt):
     assert normalize_datetime_format(xlfmt) == bfmt
 
 
+dt = datetime.datetime(2019, 12, 25, 6, 9, 5)
+
+
 @pytest.mark.parametrize('fmt_kw,expected',
                          [
                              ([dt.date(), 'MM/DD/YY', 'ru'], '12/25/19'),
@@ -135,3 +136,23 @@ def test_format_datetime(fmt_kw, expected):
                          )
 def test_format_time(fmt_kw, expected):
     assert format_time(*fmt_kw) == expected
+
+
+td = datetime.timedelta(hours=2, minutes=3, seconds=4, milliseconds=5)
+td2 = datetime.timedelta(hours=2, minutes=3, seconds=4, milliseconds=999)
+
+timedelta_arge = [
+    ([td, '[hhh]:mm:ss.000'], '002:03:04.005'),
+    ([td, '[hhh]:mm:ss.00'], '002:03:04.01'),
+    ([td2, '[hhh]:mm:ss.000'], '002:03:04.999'),
+    ([td2, '[h]:mm:ss'], '2:03:05'),
+    ([td2, '[mmmm]:ss'], '0123:05'),
+    ([td2, '[s]'], '7385'),
+    ([td, '[s].00'], '7384.01'),
+    ([td, '[hhh] - mm - ss.000 x'], '002 - 03 - 04.005 x')
+]
+
+
+@pytest.mark.parametrize('args,expected', timedelta_arge)
+def test_format_timedelta(args, expected):
+    assert format_timedelta(*args) == expected

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -85,15 +85,18 @@ test_datetime_formats = {
     'm s y m': 'm s yy M',
     'h mmm s m': 'H MMM s m',
     'h mmm m s m': 'H MMM m s M',
-    'mmm s m': 'MMM s m'
+    'h m s am': "H m s 'a'M",
+    'h m s"s"': "H m s's'",
+    'h m s\'': "H m s''",
+    'h m s\'\'': "H m s''''",
+    'h m s"\'\'"': "H m s''''",
+    'h m s"a\'"': "H m s'a'''"
 }
 
 
 @pytest.mark.parametrize('xlfmt, bfmt', test_datetime_formats.items())
 def test_normalize_format(xlfmt, bfmt):
     assert normalize_datetime_format(xlfmt) == bfmt
-    assert normalize_datetime_format(xlfmt.lower()) == bfmt
-    assert normalize_datetime_format(xlfmt.upper()) == bfmt
 
 
 @pytest.mark.parametrize('fmt_kw,expected',

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -6,6 +6,7 @@ import datetime
 import pytest
 
 from xlsx2html.format import format_decimal, format_date, format_datetime, format_time
+from xlsx2html.format.dt import normalize_datetime_format
 
 decimal_formats = [
     ([-1500, '[RED]0.00', 'ru'], '<span style="color: RED">-1500,00</span>'),
@@ -57,6 +58,42 @@ def test_currency_format(fmt_kw, expected):
 
 
 dt = datetime.datetime(2019, 12, 25, 6, 9, 5)
+
+
+test_datetime_formats = {
+    'mm-dd-yy': 'MM-dd-yy',
+    'd-mmm-yy': 'd-MMM-yy',
+    'd-mmm-yyyy': 'd-MMM-yyyy',
+    'd-mmm': 'd-MMM',
+    'mmm-yy': 'MMM-yy',
+    'h:mm AM/PM': 'h:mm a',
+    'h:mm:ss AM/PM': 'h:mm:ss a',
+    'h:mm': 'H:mm',
+    'h:mm:ss': 'H:mm:ss',
+    'm/d/yy h:mm': 'M/d/yy H:mm',
+    'mm:ss': 'mm:ss',
+    'mm:ss.0': 'mm:ss.S',
+    'yyyy-mm-dd hh:mm:ss.000': 'yyyy-MM-dd HH:mm:ss.SSS',
+    'h m m s': 'H m m s',
+    'h m m s m': 'H m m s M',
+    'h m s m': 'H m s M',
+    'm s m': 'm s M',
+    's m': 's m',
+    'h m d s m': 'H m d s M',
+    'y s d mmm m': 'yy s d MMM m',
+    'y s d m': 'yy s d m',
+    'm s y m': 'm s yy M',
+    'h mmm s m': 'H MMM s m',
+    'h mmm m s m': 'H MMM m s M',
+    'mmm s m': 'MMM s m'
+}
+
+
+@pytest.mark.parametrize('xlfmt, bfmt', test_datetime_formats.items())
+def test_normalize_format(xlfmt, bfmt):
+    assert normalize_datetime_format(xlfmt) == bfmt
+    assert normalize_datetime_format(xlfmt.lower()) == bfmt
+    assert normalize_datetime_format(xlfmt.upper()) == bfmt
 
 
 @pytest.mark.parametrize('fmt_kw,expected',

--- a/xlsx2html/constants/builtin.py
+++ b/xlsx2html/constants/builtin.py
@@ -1,6 +1,7 @@
 # http://unicode.org/reports/tr35/tr35-dates.html#Date_Format_Patterns
 
 BUILTIN_FORMATS = {
+    0: 'General',
     1: '0',
     2: '0.00',
     3: '#,##0',
@@ -15,16 +16,16 @@ BUILTIN_FORMATS = {
     12: '# ?/?',
     13: '# ??/??',
 
-    14: 'MM-dd-yy',
-    15: 'd-MMM-yy',
-    16: 'd-MMM',
-    17: 'MMM-yy',
+    14: 'mm-dd-yy',
+    15: 'd-mmm-yy',
+    16: 'd-mmm',
+    17: 'mmm-yy',
 
     18: 'h:mm AM/PM',
     19: 'h:mm:ss AM/PM',
     20: 'h:mm',
     21: 'h:mm:ss',
-    22: 'M/d/yyyy h:mm',
+    22: 'm/d/yy h:mm',
 
     37: '#,##0_);(#,##0)',
     38: '#,##0_);[Red](#,##0)',

--- a/xlsx2html/format/__init__.py
+++ b/xlsx2html/format/__init__.py
@@ -7,7 +7,7 @@ from babel.numbers import (
 )
 
 from xlsx2html.constants import BUILTIN_FORMATS
-from .dt import format_time, format_datetime, format_date
+from .dt import format_time, format_datetime, format_date, format_timedelta
 from .hyperlink import format_hyperlink
 from .locale import extract_locale_from_format
 from .number import format_decimal
@@ -40,6 +40,8 @@ def format_cell(cell, locale=None, f_cell=None):
         formatted_value = format_datetime(value, cell_format, locale=locale)
     elif type(value) == datetime.time:
         formatted_value = format_time(value, cell_format, locale=locale)
+    elif type(value) == datetime.timedelta:
+        formatted_value = format_timedelta(value, cell_format)
 
     formatted_value = format_hyperlink(formatted_value, cell, f_cell)
 

--- a/xlsx2html/format/__init__.py
+++ b/xlsx2html/format/__init__.py
@@ -27,7 +27,6 @@ def format_cell(cell, locale=None, f_cell=None):
 
     locale = locale or LC_TIME
 
-    # Possible problem with dd-mmm and more
     cell_format = BUILTIN_FORMATS.get(cell._style.numFmtId, cell_format)
     cell_format = cell_format.split(';')[0]
 

--- a/xlsx2html/format/dt.py
+++ b/xlsx2html/format/dt.py
@@ -4,6 +4,7 @@ import re
 
 from babel import dates as babel_dates
 from babel.dates import LC_TIME
+import datetime as dt
 
 RE_DATE_TOK = re.compile(r'(?:\\[\\*_"]?|_.|\*.|y+|m+|d+|h+|s+|\.0+|am/pm|a/p|"[^"]*")', re.I)
 MAYBE_MINUTE = ['m', 'mm']
@@ -48,7 +49,7 @@ def normalize_datetime_format(fmt):
                 g = f"'{g}'"
             return g
         t = ''.join(plain)
-        t = re.sub(r"[a-z']+", s, t)
+        t = re.sub(r"[a-z']+", s, t, re.I)
         return t
 
     for i, (text, start, end) in enumerate(found):
@@ -110,14 +111,18 @@ def normalize_datetime_format(fmt):
 
 def format_date(date, fmt, locale=LC_TIME):
     fmt = normalize_datetime_format(fmt)
-    return babel_dates.format_date(date, fmt, locale)
+    datetime = dt.datetime.combine(date, dt.time())
+    return babel_dates.format_datetime(datetime, fmt, locale)
 
 
-def format_datetime(date, fmt, locale=LC_TIME, tzinfo=None):
+def format_datetime(datetime, fmt, locale=LC_TIME, tzinfo=None):
     fmt = normalize_datetime_format(fmt)
-    return babel_dates.format_datetime(date, fmt, locale=locale, tzinfo=tzinfo)
+    return babel_dates.format_datetime(datetime, fmt, locale=locale, tzinfo=tzinfo)
 
 
-def format_time(date, fmt, locale=LC_TIME, tzinfo=None):
+def format_time(time, fmt, locale=LC_TIME, tzinfo=None):
     fmt = normalize_datetime_format(fmt)
-    return babel_dates.format_time(date, fmt, locale=locale, tzinfo=tzinfo)
+    # Excel times are treated as 1900-01-00, which doesn't exist.
+    # Also day of week is deliberately off by one before 1900-03-01
+    datetime = dt.datetime.combine(dt.date(1899, 12, 31), time)
+    return babel_dates.format_datetime(datetime, fmt, locale=locale, tzinfo=tzinfo)

--- a/xlsx2html/format/dt.py
+++ b/xlsx2html/format/dt.py
@@ -49,7 +49,6 @@ def normalize_datetime_format(fmt):
             return g
         t = ''.join(plain)
         t = re.sub(r"[a-z']+", s, t)
-        print(plain, repr(t))
         return t
 
     for i, (text, start, end) in enumerate(found):

--- a/xlsx2html/format/dt.py
+++ b/xlsx2html/format/dt.py
@@ -130,11 +130,15 @@ def format_datetime(datetime, fmt, locale=LC_TIME, tzinfo=None):
     return babel_dates.format_datetime(datetime, fmt, locale=locale, tzinfo=tzinfo)
 
 
-def format_time(time, fmt, locale=LC_TIME, tzinfo=None):
+def format_time(time, fmt, locale=LC_TIME, tzinfo=None, date=None):
     # Excel times are treated as Saturday 1900-01-00, which doesn't exist.
     # So use Saturday 1900-01-06 and force day to 0 instead
-    fmt = normalize_datetime_format(fmt, fixed_for_time=True)
-    datetime = dt.datetime.combine(dt.date(1900, 1, 6), time)
+    fixed_for_time = False
+    if date is None:
+        date = dt.date(1900, 1, 6)
+        fixed_for_time = True
+    datetime = dt.datetime.combine(date, time)
+    fmt = normalize_datetime_format(fmt, fixed_for_time=fixed_for_time)
     return babel_dates.format_datetime(datetime, fmt, locale=locale, tzinfo=tzinfo)
 
 

--- a/xlsx2html/format/dt.py
+++ b/xlsx2html/format/dt.py
@@ -5,68 +5,79 @@ import re
 from babel import dates as babel_dates
 from babel.dates import LC_TIME
 
-DATE_REPLACES = {
-    'DD': 'dd',
-    'YYYY': 'yyyy',
-    'YY': 'yy',
-}
-RE_TIME = re.compile(
-    r"""
-        \b
-        (?P<hours>[H]{1,2})
-        .?
-        (?P<minutes>[M]{1,2})
-        (?:
-            .?
-            (?P<seconds>[S]{1,2})
-            |
-        )
-        (?:
-            .+?
-            (?P<h12>AM/PM)
-            |
-        )
-        \b
-        """,
-    re.VERBOSE
-
-)
-FIX_TIME_REPLACES = {
-    r'\b([H]{1,2}).?([M]{1,2}).?([S]{1,2}).+?(AM/PM)\b': r'hh\1m\2s\3a',
-    r'\bHH(.?)MM(.?)SS\b': r'H\1m\2s',
-    r'AM/PM': 'a'
-}
+RE_DATE_TOK = re.compile(r"(?:y+|m+|d+|h+|s+|\.0+|am/pm|a/p)", re.I)
+MAYBE_MINUTE = ['m', 'mm']
 
 
+def normalize_datetime_format(fmt):
+    has_ap = False
+    is_minute = set()
+    must_minute = False
+    found = [(m.group(0).lower(), *m.span()) for m in RE_DATE_TOK.finditer(fmt)]
+    for i, (tok, start, end) in enumerate(found):
+        if tok in ['am/pm', 'a/p']:
+            has_ap = True
+        elif tok[0] == 'h':
+            # First m after h is always minute
+            must_minute = True
+        elif must_minute and tok in ['m', 'mm']:
+            is_minute.add(i)
+            must_minute = False
+        elif tok[0] == 's':
+            last_i = i - 1
+            if last_i < 0:
+                must_minute = True
+            elif last_i not in is_minute:
+                if found[last_i][0] in ['m', 'mm']:
+                    # m right before s is always minute
+                    is_minute.add(last_i)
+                elif not len(is_minute):
+                    # if no previous m, first m after s is always minute
+                    must_minute = True
 
-def normalize_date_format(_format):
-    for f, to in DATE_REPLACES.items():
-        _format = _format.replace(f, to)
-    return _format
-
-
-def normalize_time_format(_format):
-    def replace_time(m):
-        groups = m.groupdict()
-        text = m.group(0).lower()
-        if groups.get('h12'):
-            text = text.replace(groups['h12'].lower(), 'a')
+    parts = []
+    pos = 0
+    for i, (tok, start, end) in enumerate(found):
+        parts.append(fmt[pos:start])
+        if tok[0] == 'h':
+            tok = tok[:2]
+            if not has_ap:
+                tok = tok.upper()
+        elif tok[0] == 'm':
+            if len(tok) > 5:
+                tok = tok[:4]  # Defaults to MMMM
+            if len(tok) > 2 or i not in is_minute:
+                tok = tok.upper()
+        elif tok[0] == 's':
+            tok = tok[:2]
+        elif tok[:2] == '.0':
+            tok = tok.replace('0', 'S')
+        elif tok == 'am/pm':
+            tok = 'a'
+        elif tok == 'a/p':
+            # Fudging presentation to AM; maybe should be A in some cases?
+            tok = 'a'
+        elif tok[0] == 'y':
+            if len(tok) > 2:
+                tok = 'yyyy'
+            else:
+                tok = 'yy'
+        elif tok[0] == 'd':
+            if len(tok) == 3:
+                tok = 'EEE'
+            elif len(tok) >= 4:
+                tok = 'EEEE'
         else:
-            text = text.replace('h', 'H')
-        return text
+            raise ValueError(f'Unhandled datetime token {tok}')
+        parts.append(tok)
+        pos = end
+    parts.append(fmt[pos:])
 
-    _format = RE_TIME.sub(replace_time, _format)
-    return _format.replace('\\', '')
-
-
-def normalize_datetime_format(_format):
-    for fn in [normalize_time_format, normalize_date_format]:
-        _format = fn(_format)
-    return _format.replace('\\', '')
+    return ''.join(parts)
 
 
 def format_date(date, fmt, locale=LC_TIME):
-    fmt = normalize_date_format(fmt)
+    fmt = normalize_datetime_format(fmt)
     return babel_dates.format_date(date, fmt, locale)
 
 
@@ -76,5 +87,5 @@ def format_datetime(date, fmt, locale=LC_TIME, tzinfo=None):
 
 
 def format_time(date, fmt, locale=LC_TIME, tzinfo=None):
-    fmt = normalize_time_format(fmt)
+    fmt = normalize_datetime_format(fmt)
     return babel_dates.format_time(date, fmt, locale=locale, tzinfo=tzinfo)

--- a/xlsx2html/format/dt.py
+++ b/xlsx2html/format/dt.py
@@ -7,6 +7,7 @@ from babel.dates import LC_TIME
 import datetime as dt
 
 RE_DATE_TOK = re.compile(r'(?:\\[\\*_"]?|_.|\*.|y+|m+|d+|h+|s+|\.0+|am/pm|a/p|"[^"]*")', re.I)
+RE_TD_TOK = re.compile(r'(?:\\[\\*_"]?|_.|\*.|\[h+\]|\[m+\]|\[s+\](?:\.0+)?|m+|s+(?:\.0+)?|h+|y+|d+|"[^"]*")', re.I)
 MAYBE_MINUTE = ['m', 'mm']
 DATE_PERIOD = ['am/pm', 'a/p']
 
@@ -18,15 +19,16 @@ def normalize_datetime_format(fmt, fixed_for_time=False):
     found = [(m.group(0), *m.span()) for m in RE_DATE_TOK.finditer(fmt)]
     for i, (text, start, end) in enumerate(found):
         tok = text.lower()
+        tok_type = tok[0]
         if tok in DATE_PERIOD:
             has_ap = True
-        elif tok[0] == 'h':
+        elif tok_type == 'h':
             # First m after h is always minute
             must_minute = True
         elif must_minute and tok in MAYBE_MINUTE:
             is_minute.add(i)
             must_minute = False
-        elif tok[0] == 's':
+        elif tok_type == 's':
             last_i = i - 1
             if last_i < 0:
                 must_minute = True
@@ -54,45 +56,46 @@ def normalize_datetime_format(fmt, fixed_for_time=False):
 
     for i, (text, start, end) in enumerate(found):
         tok = text.lower()
+        tok_type = tok[0]
         plain.append(fmt[pos:start])
         pos = end
-        if tok[0] == '\\':
+        if tok_type == '\\':
             # Escape sequence \*_"
             plain.append(text[1:])
             continue
-        elif tok[0] == '_':
+        elif tok_type == '_':
             # normally puts space at same size as next character; just treat as space
             plain.append(' ')
             continue
-        elif tok[0] == '*':
+        elif tok_type == '*':
             # Don't include repeating character
             continue
-        elif tok[0] == '"':
+        elif tok_type == '"':
             # Quoted string
             plain.append(text[1:-1])
             continue
-        elif tok[0] == 'h':
+        elif tok_type == 'h':
             tok = tok[:2]
             if not has_ap:
                 tok = tok.upper()
-        elif tok[0] == 'm':
+        elif tok_type == 'm':
             if len(tok) > 5:
                 tok = tok[:4]  # Defaults to MMMM
             if len(tok) > 2 or i not in is_minute:
                 tok = tok.upper()
-        elif tok[0] == 's':
+        elif tok_type == 's':
             tok = tok[:2]
-        elif tok[:2] == '.0':
+        elif tok_type == '.':
             tok = tok.replace('0', 'S')
         elif tok in DATE_PERIOD:
             # Fudging A/P to AM; maybe should be A in some cases?
             tok = 'a'
-        elif tok[0] == 'y':
+        elif tok_type == 'y':
             if len(tok) > 2:
                 tok = 'yyyy'
             else:
                 tok = 'yy'
-        elif tok[0] == 'd':
+        elif tok_type == 'd':
             if len(tok) == 3:
                 tok = 'EEE'
             elif len(tok) >= 4:
@@ -133,3 +136,63 @@ def format_time(time, fmt, locale=LC_TIME, tzinfo=None):
     fmt = normalize_datetime_format(fmt, fixed_for_time=True)
     datetime = dt.datetime.combine(dt.date(1900, 1, 6), time)
     return babel_dates.format_datetime(datetime, fmt, locale=locale, tzinfo=tzinfo)
+
+
+def format_timedelta(timedelta, fmt):
+    e_s = timedelta.total_seconds()
+    e_m, s = divmod(e_s, 60)
+    e_m = int(e_m)
+    e_h, m = divmod(e_m, 60)
+
+    plain = []
+    pos = 0
+
+    for match in RE_TD_TOK.finditer(fmt):
+        text = match.group(0)
+        start, end = match.span()
+        tok = text.lower()
+        plain.append(fmt[pos:start])
+        pos = end
+        tok_type = tok[0]
+        if tok_type == '[':
+            tok_type = tok[:2]
+        if tok_type == '\\':
+            # Escape sequence \*_"
+            plain.append(text[1:])
+        elif tok_type == '_':
+            # normally puts space at same size as next character; just treat as space
+            plain.append(' ')
+        elif tok_type == '*':
+            # Don't include repeating character
+            pass
+        elif tok_type == '"':
+            # Quoted string
+            plain.append(text[1:-1])
+        elif tok_type == '[h':
+            f = "{:0>" + str(len(tok) - 2) + "}"
+            plain.append(f.format(e_h))
+        elif tok_type == '[m':
+            f = "{:0>" + str(len(tok) - 2) + "}"
+            plain.append(f.format(e_m))
+        elif tok_type == '[s':
+            if '.' in tok:
+                stok, mstok = tok.split('.')
+                f = "{:0" + str(len(tok) - 2) + "." + str(len(mstok)) + "f}"
+            else:
+                f = "{:0" + str(len(tok) - 2) + ".0f}"
+            plain.append(f.format(e_s))
+        elif tok == 'm':
+            plain.append(str(m))
+        elif tok == 'mm':
+            plain.append(f"{m:0>2}")
+        elif tok_type == 's':
+            if '.' in tok:
+                mstok = tok.split('.')[1]
+                f = "{:0" + str(min(len(tok), 2) + len(mstok) + 1) + "." + str(len(mstok)) + "f}"
+            else:
+                f = "{:0" + str(min(len(tok), 2)) + ".0f}"
+            plain.append(f.format(s))
+        else:
+            raise ValueError(f'Unhandled datetime token {tok}')
+    plain.append(fmt[pos:])
+    return ''.join(plain)

--- a/xlsx2html/format/dt.py
+++ b/xlsx2html/format/dt.py
@@ -180,7 +180,7 @@ def format_timedelta(timedelta, fmt):
             plain.append(f.format(e_m))
         elif tok_type == '[s':
             if '.' in tok:
-                stok, mstok = tok.split('.')
+                mstok = tok.split('.')[0]
                 f = "{:0" + str(len(tok) - 2) + "." + str(len(mstok)) + "f}"
             else:
                 f = "{:0" + str(len(tok) - 2) + ".0f}"

--- a/xlsx2html/format/dt.py
+++ b/xlsx2html/format/dt.py
@@ -11,7 +11,7 @@ MAYBE_MINUTE = ['m', 'mm']
 DATE_PERIOD = ['am/pm', 'a/p']
 
 
-def normalize_datetime_format(fmt):
+def normalize_datetime_format(fmt, fixed_for_time=False):
     has_ap = False
     is_minute = set()
     must_minute = False
@@ -99,6 +99,13 @@ def normalize_datetime_format(fmt):
                 tok = 'EEEE'
         else:
             raise ValueError(f'Unhandled datetime token {tok}')
+        if fixed_for_time:
+            if tok == 'd':
+                plain.append('0')
+                continue
+            elif tok == 'dd':
+                plain.append('00')
+                continue
         if len(plain):
             parts.append(clean_plain())
             plain = []
@@ -121,8 +128,8 @@ def format_datetime(datetime, fmt, locale=LC_TIME, tzinfo=None):
 
 
 def format_time(time, fmt, locale=LC_TIME, tzinfo=None):
-    fmt = normalize_datetime_format(fmt)
-    # Excel times are treated as 1900-01-00, which doesn't exist.
-    # Also day of week is deliberately off by one before 1900-03-01
-    datetime = dt.datetime.combine(dt.date(1899, 12, 31), time)
+    # Excel times are treated as Saturday 1900-01-00, which doesn't exist.
+    # So use Saturday 1900-01-06 and force day to 0 instead
+    fmt = normalize_datetime_format(fmt, fixed_for_time=True)
+    datetime = dt.datetime.combine(dt.date(1900, 1, 6), time)
     return babel_dates.format_datetime(datetime, fmt, locale=locale, tzinfo=tzinfo)


### PR DESCRIPTION
Handles date/datetime/time parsing in an excel-similar manner. 

- "m/mm" may be minute or month; rules for when to be what mimic how excel handles it
- Handles '_', '\\', '*' escape sequences
- Handles double-quoted text in format
- Formats dates as time 00:00
- Formats time as date Saturday 1900-01-00 (which does not exist)
- Does not fully handle "A/P" (see note)
- Does not handle timedeltas (neither does original)
- Allows formatting of dates 1900-01-01, unlike Excel
- Dates prior to 1900-03-01 have correct day of week, unlike Excel

NOTE: Excel allows you to specify "AM/PM" or "A/P". If you specify "AM/PM", this will be translated to "AM" or "PM" for the specified locale. However if you specify "A/P" in en-US, it will be "A" or "P". However, for other locales it may not, and may just be the usual locale-specific am/pm. The babel package that is being used internally does not provide for such a short-form AM/PM format. Since it is unclear how to consistently handle A/P, and no obvious way to do so with babel (which we need to correctly handle locale), we are simply treating A/P like AM/PM. 