### PR TITLE
TO suppress AttributeError: 'GradientFill' object has no attribute 'p…

### DIFF
--- a/xlsx2html/core.py
+++ b/xlsx2html/core.py
@@ -1,3 +1,4 @@
+import contextlib
 import io
 from collections import defaultdict
 from typing import List
@@ -97,9 +98,11 @@ def get_styles_from_cell(cell, merged_cell_map=None, default_cell_border="none")
     if cell.alignment.horizontal:
         h_styles["text-align"] = cell.alignment.horizontal
 
-    if cell.fill.patternType == "solid":
-        # TODO patternType != 'solid'
-        h_styles["background-color"] = normalize_color(cell.fill.fgColor)
+    with contextlib.suppress(AttributeError):
+        if cell.fill.patternType == "solid":
+            # TODO patternType != 'solid'
+            h_styles["background-color"] = normalize_color(cell.fill.fgColor)
+
     if cell.font:
         h_styles["font-size"] = "%spx" % cell.font.sz
         if cell.font.color:


### PR DESCRIPTION
```
    s = xlsx2html(template_file)
  File "C:\Users\n1majne3\AppData\Local\Programs\Python\Python39\lib\site-packages\xlsx2html\core.py", line 352, in xlsx2html
    data = worksheet_to_data(ws, locale=locale, fs=fs, default_cell_border=default_cell_border)
  File "C:\Users\n1majne3\AppData\Local\Programs\Python\Python39\lib\site-packages\xlsx2html\core.py", line 221, in worksheet_to_data
    get_styles_from_cell(cell, merged_cell_info, default_cell_border)
  File "C:\Users\n1majne3\AppData\Local\Programs\Python\Python39\lib\site-packages\xlsx2html\core.py", line 95, in get_styles_from_cell
    if cell.fill.patternType == 'solid':
  File "C:\Users\n1majne3\AppData\Local\Programs\Python\Python39\lib\site-packages\openpyxl\styles\proxy.py", line 24, in __getattr__
    return getattr(self.__target, attr)
AttributeError: 'GradientFill' object has no attribute 'patternType'
```