### PR TITLE
fix Cell object is not iterable #30

### DIFF
--- a/xlsx2html/core.py
+++ b/xlsx2html/core.py
@@ -171,6 +171,11 @@ def worksheet_to_data(ws, locale=None, fs=None, default_cell_border="none"):
         )
 
     for cell_range in merged_cell_ranges:
+        if ":" not in str(cell_range):
+            cell_range_list = list(ws[f"{cell_range}:{cell_range}"])
+        else:
+            cell_range_list = list(ws[cell_range])
+
         cell_range_list = list(ws[cell_range])
         m_cell = cell_range_list[0][0]
 


### PR DESCRIPTION
Actual Issue i faced: while reading excel file, cell_range value is "A30" (excel cell value) which is not merged_cell_range but somehow the value sometimes comes in "merged_cell_ranges"
hence the solution is making it as "A30:A30" which works with the output format of list(ws[cell_range])

replacing the below line  
```
            cell_range_list = list(ws[cell_range])

```
with the below code:

```
    for cell_range in merged_cell_ranges:
        if ":" not in str(cell_range):
            cell_range_list = list(ws[f"{cell_range}:{cell_range}"])
        else:
            cell_range_list = list(ws[cell_range])

```  
currently i have made changes the following core file it works fine.
path is venv/lib/python3.10/site-packages/xlsx2html/core.py
@Apkawa  please include the fix