### PR TITLE
fix: remove warnings and update supported version

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+per-file-ignores =
+    */migrations/* ALL

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,16 +2,16 @@
 ```bash
 pip install -r requirements.txt
 pytest # run tests
-tox # run test matrix
+python -m tox # run test matrix
 ```
 
 # Run tests with pyenv with specific python and pypy
 
 ```
-pyenv install 3.10-dev pypy3.7-7.3.5
-pyenv local 3.10-dev pypy3.7-7.3.5
+pyenv install 3.12 pypy7.3.5
+pyenv local 3.12 pypy7.3.5
 pip install -r requirements.txt
-tox -e py310,pypy3
+python -m tox -e py312,pypy7
 ```
 
 
@@ -22,3 +22,4 @@ pre-commit install
 ```
 
 For pycharm needs install `tox` to global
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,10 +2,5 @@
 python_files=tests.py test_*.py
 addopts = --ignore=node_modules --ignore=static -r fesxXR --doctest-modules  -v
 
-python_paths = ./
-
-flakes-ignore =
-    */migrations/* ALL
-
-pep8ignore =
-    */migrations/* ALL
+markers =
+    webtest: mark a test as a webtest.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,11 +5,10 @@ wheel>=0.36.2
 twine>=1.15.0
 setuptools>=42
 # Test
-tox==3.14.2
-tox-pyenv==1.1.0
-pytest==6.2.4
-pytest-flake8==1.0.7
-pytest-cov==2.12.1
+tox==4.23.2
+pytest==8.3.4
+pytest-flake8==1.3.0
+pytest-cov==6.0.0
 pytest-splinter==3.3.2
 splinter>=0.21,<0.22
 #chromedriver-binary-auto

--- a/xlsx2html/core.py
+++ b/xlsx2html/core.py
@@ -346,7 +346,7 @@ def get_sheet(wb, sheet):
     ws = wb.active
     if sheet is not None:
         try:
-            ws = wb.get_sheet_by_name(sheet)
+            ws = wb[sheet]
         except KeyError:
             ws = wb.worksheets[sheet]
     return ws

--- a/xlsx2html/utils/image.py
+++ b/xlsx2html/utils/image.py
@@ -1,7 +1,7 @@
 import base64
 import mimetypes
 
-from typing.io import BinaryIO
+from typing import BinaryIO
 
 
 class FileNotFoundError(Exception):


### PR DESCRIPTION
This pull request fixes the following warning and updates the dependencies.

`
/usr/src/.venv/lib/python3.11/site-packages/xlsx2html/utils/image.py:4: DeprecationWarning: [Typing Practice for Programmers | typing.io](http://typing.io/)  is deprecated, import directly from typing instead. [Typing Practice for Programmers | typing.io](http://typing.io/)  will be removed in Python 3.12.`